### PR TITLE
QT_STATIC_CONST has been removed from QT

### DIFF
--- a/ground/openpilotgcs/src/libs/qwt/src/qwt_transform.h
+++ b/ground/openpilotgcs/src/libs/qwt/src/qwt_transform.h
@@ -107,8 +107,8 @@ public:
 
     virtual QwtTransform *copy() const;
 
-    QT_STATIC_CONST double LogMin;
-    QT_STATIC_CONST double LogMax;
+    static const double LogMin;
+    static const double LogMax;
 };
 
 /*!


### PR DESCRIPTION
QT has removed the macro, one should use "static const" instead:

https://qt.gitorious.org/qt/qtbase/commit/11c30f9705e796ebabcdd868bce3ad3664cc06eb