### PR TITLE
Fixed compilation with qt5.5

### DIFF
--- a/ground/openpilotgcs/src/libs/utils/xmlconfig.h
+++ b/ground/openpilotgcs/src/libs/utils/xmlconfig.h
@@ -36,6 +36,7 @@
 #include <QSettings>
 #include <QDomElement>
 #include <QObject>
+#include <QtCore/QDataStream>
 
 class XMLCONFIG_EXPORT XmlConfig : QObject {
     Q_OBJECT

--- a/ground/openpilotgcs/src/plugins/hitl/xplanesimulator.h
+++ b/ground/openpilotgcs/src/plugins/hitl/xplanesimulator.h
@@ -30,6 +30,7 @@
 
 #include <QObject>
 #include <simulator.h>
+#include <QtCore/QDataStream>
 
 class XplaneSimulator : public Simulator {
     Q_OBJECT

--- a/ground/openpilotgcs/src/plugins/notify/notifytablemodel.h
+++ b/ground/openpilotgcs/src/plugins/notify/notifytablemodel.h
@@ -32,6 +32,7 @@
 #include <QAbstractTableModel>
 #include <QList>
 #include "notificationitem.h"
+#include <QtCore/QDataStream>
 
 enum ColumnNames { eMessageName, eRepeatValue, eExpireTimer, eTurnOn };
 

--- a/ground/openpilotgcs/src/shared/qtsingleapplication/qtlocalpeer.h
+++ b/ground/openpilotgcs/src/shared/qtsingleapplication/qtlocalpeer.h
@@ -31,6 +31,7 @@
 #include <QtNetwork/QLocalServer>
 #include <QtNetwork/QLocalSocket>
 #include <QtCore/QDir>
+#include <QtCore/QDataStream>
 
 namespace SharedTools {
 class QtLocalPeer : public QObject {


### PR DESCRIPTION
This adds the necessary libraries for compiling the GCS with qt5.5.
I did not test with the previous QT version so it might cause issues there. 
